### PR TITLE
Enables h5 format for image output

### DIFF
--- a/src/main_cg.cpp
+++ b/src/main_cg.cpp
@@ -102,7 +102,7 @@ int main_cg(args::Subparser &parser)
     log.info("Volume {}: {}", iv, log.toNow(vol_start));
   }
   log.info("All Volumes: {}", log.toNow(all_start));
-  auto const ofile = OutName(fname, oname, "cg");
+  auto const ofile = OutName(fname, oname, "cg", outftype.Get());
   if (magnitude) {
     WriteVolumes(info, R4(out.abs()), volume.Get(), ofile, log);
   } else {

--- a/src/main_rss.cpp
+++ b/src/main_rss.cpp
@@ -49,7 +49,7 @@ int main_rss(args::Subparser &parser)
   }
   log.info("All volumes: {}", log.toNow(all_start));
 
-  WriteVolumes(info, out, volume.Get(), OutName(fname, oname, "rss"), log);
+  WriteVolumes(info, out, volume.Get(), OutName(fname, oname, "rss", outftype.Get()), log);
   FFT::End(log);
   return EXIT_SUCCESS;
 }

--- a/src/main_sense.cpp
+++ b/src/main_sense.cpp
@@ -67,13 +67,13 @@ int main_sense(args::Subparser &parser)
           : cropper.crop4(SENSE(
                 info, trajectory, osamp.Get(), stack, kernel, false, thresh.Get(), rad_ks, log));
   if (save_maps) {
-    WriteNifti(info, Cx4(sense.shuffle(Sz4{1, 2, 3, 0})), OutName(fname, oname, "sense-maps"), log);
+    WriteNifti(info, Cx4(sense.shuffle(Sz4{1, 2, 3, 0})), OutName(fname, oname, "sense-maps", outftype.Get()), log);
   }
   if (save_kernels) {
     FFT3N kernelFFT(sense, log);
     kernelFFT.forward();
     WriteNifti(
-        info, Cx4(sense.shuffle(Sz4{1, 2, 3, 0})), OutName(fname, oname, "sense-kernels"), log);
+        info, Cx4(sense.shuffle(Sz4{1, 2, 3, 0})), OutName(fname, oname, "sense-kernels", outftype.Get()), log);
     kernelFFT.reverse();
   }
 
@@ -115,7 +115,7 @@ int main_sense(args::Subparser &parser)
   }
   log.info("All Volumes: {}", log.toNow(all_start));
 
-  auto const ofile = OutName(fname, oname, "sense");
+  auto const ofile = OutName(fname, oname, "sense", outftype.Get());
   if (magnitude) {
     WriteVolumes(info, R4(out.abs()), volume.Get(), ofile, log);
   } else {

--- a/src/main_tgv.cpp
+++ b/src/main_tgv.cpp
@@ -102,7 +102,7 @@ int main_tgv(args::Subparser &parser)
     out.chip(iv, 3) = image;
     log.info("Volume {}: {}", iv, log.toNow(start));
   }
-  auto const ofile = OutName(fname, oname, "tgv");
+  auto const ofile = OutName(fname, oname, "tgv", outftype.Get());
   if (magnitude) {
     WriteVolumes(info, R4(out.abs()), volume.Get(), ofile, log);
   } else {

--- a/src/parse_args.h
+++ b/src/parse_args.h
@@ -49,4 +49,6 @@ WriteVolumes(Info const &info, T const &vols, long const which, std::string cons
   args::ValueFlag<float> tukey_e(                                                                  \
       parser, "TUKEY END", "End-width of Tukey filter", {"tukey_end"}, 1.0f);                      \
   args::ValueFlag<float> tukey_h(                                                                  \
-      parser, "TUKEY HEIGHT", "End height of Tukey filter", {"tukey_height"}, 0.0f);
+      parser, "TUKEY HEIGHT", "End height of Tukey filter", {"tukey_height"}, 0.0f);               \
+  args::ValueFlag<std::string> outftype(                                                           \
+      parser, "OUT FILETYPE", "File type of output (nii/nii.gz/img/h5)", {"oft"}, "nii");


### PR DESCRIPTION
Implements additional output formats (as supported by ITK) as well as "raw" image output in `.h5` format by a new common recon argument `--oft`. 

Tested with phantom data and works to save to `.h5`, `.nii`, `.nii.gz`, `.img`/`.hdr`. 