### PR TITLE
Modified read_riesling() to also load image data

### DIFF
--- a/matlab/read_riesling.m
+++ b/matlab/read_riesling.m
@@ -1,19 +1,37 @@
-function [kspace, traj, info] = read_riesling(fname)
-% READ_RIESLING reads radial k-space data from riesling .h5 file
+function varargout = read_riesling(fname)
+% READ_RIESLING reads radial k-space or image data from riesling .h5 file
 %
 % Inputs:
 %   - fname: file name
 %
 % Outputs:
-%   - data: Radial k-space data
-%   - traj: Trajectory
+%   - data: Radial k-space data or image data
 %   - info: Info structure
+%   - traj: Trajectory (only in case of k-space data)
 %
 % Emil Ljungberg, King's College London, 2021
+% Martin Krämer, University Hospital Jena, 2021
 
+% get h5 file info and check if image data is present
+file_info = h5info(fname);
+is_img_data = any(contains({file_info.Datasets.Name}, 'image'));
+
+if is_img_data % load only image data
+    data = h5read(fname, '/image');
+    img = data.r + 1j*data.i;
+    
+    varargout{1} = img;
+else % load k-space data and trajectory
+    traj = h5read(fname, '/trajectory');
+    data = h5read(fname, '/noncartesian');
+    kspace = data.r + 1j*data.i;
+
+    varargout{1} = kspace;
+    varargout{3} = traj;
+end
+
+% always read info 
 info = h5read(fname, '/info');
-traj = h5read(fname, '/trajectory');
-data = h5read(fname, '/noncartesian');
-kspace = data.r + 1j*data.i;
+varargout{2} = info;
 
 end

--- a/matlab/riesling_matlab_demo.m
+++ b/matlab/riesling_matlab_demo.m
@@ -12,7 +12,7 @@
 % 
 % This will greate a phantom dataset which we can run our tests with
 
-[kspace, traj, info] = read_riesling('sl_phantom.h5');
+[kspace, info, traj] = read_riesling('sl_phantom.h5');
 
 % Size of datastructures
 % kspace: [nrcv, npoints, nspokes, nvol]


### PR DESCRIPTION
A small modification that allows the read_riesling MATLAB wrapper to also load riesling image data. It basically checks the h5 header if an "image" tag is present and then only loads image and info data. If not it will load k-space, trajectory and info.

For better and consistent usage I did change the order of the output arguments. Before it was [k-space, traj, info] and now it's [k-space, info, traj]. Because then in case of image data it will just return [image, info] meaning that the data (k-space or image) is always in the first place, info is always in the second and a third parameter is only used for the trajectory in case of k-space data.