### PR TITLE
Matlab Interface updates for "riesling nufft"

### DIFF
--- a/matlab/riesling.m
+++ b/matlab/riesling.m
@@ -1,0 +1,78 @@
+function [output] = riesling(cmd, K, Traj, varargin)
+% RIESLING Call RIESLING command from Matlab.
+%   [varargout] = RIESLING(cmd, varargin) to run given riesling command (cmd) using the
+%   data arrays/matrices passed as varargin.
+%
+%   [A, B] = RIESLING('command', X, Y) call command with inputs X Y and outputs A B
+%
+%   To output a list of available riesling commands simply run "riesling". To
+%   output the help for a specific riesling command type "riesling command -h".
+%
+% Parameters:
+%   cmd:        Command to run as string (including non data parameters)
+%   varargin:   Data arrays/matrices used as input
+%
+% Example:
+%   riesling traj -h
+%   recon = riesling('nufft -i traj', data) call nufft with inputs data
+%
+
+% Code heavily modified from bart.m from the bart toolbox, original by Martin
+% Uecker and Soumick Chatterjee. 
+% Authors:
+% 2021 Patrick Fuchs (p.fuchs@ucl.ac.uk)
+%
+
+if nargin < 4
+    Info = riesling_info;
+else
+    Info = varargin{1};
+end
+
+fileNameIn = [tempname,'.h5'];
+[~,name] = fileparts(fileNameIn);
+
+opts = strsplit(cmd);
+cmd  = opts{1};
+opts = sprintf('%s ',opts{2:end});
+
+% Adjust tensor name to fit riesling convention w.r.t. nufft command (that
+% is, "image" for the image domain cartesian data, and "nufft-forward" for
+% the artificially generated non-uniform fourier space dataset).
+if strcmpi(cmd,'nufft')
+    if any(regexpi(opts,'--fwd'))
+        riesling_write(fileNameIn, K, Traj, Info, 'image');
+    else
+        riesling_write(fileNameIn, K, Traj, Info, 'nufft-forward');
+    end
+else
+    riesling_write(fileNameIn, K, Traj, Info, 'noncartesian');
+end
+
+
+try
+    [ERR] = system(['riesling ',cmd,' ',fileNameIn,' ',opts]);
+    
+    if ERR ~= 0
+        delete(fileNameIn);
+        error('Failure during system call, please refer to log for more info.')
+    end
+    
+    fileNameOut = deblank(ls([name,'*.h5']));
+    output = riesling_read(fileNameOut);
+    
+catch 
+    delete(fileNameIn);
+    try
+        fileNameOut = deblank(ls([name,'*.h5']));
+        delete(fileNameOut);
+    catch
+        fprintf('No output generated.\n');
+    end
+end
+
+delete(fileNameIn);
+delete(fileNameOut);
+
+
+end

--- a/matlab/riesling_read.m
+++ b/matlab/riesling_read.m
@@ -11,6 +11,7 @@ function varargout = riesling_read(fname)
 %
 % Emil Ljungberg, King's College London, 2021
 % Martin Krämer, University Hospital Jena, 2021
+% Patrick Fuchs, University College London, 2022
 
 % always read info 
 info = h5read(fname, '/info');
@@ -18,8 +19,22 @@ info = h5read(fname, '/info');
 % Open h5 file
 file_info = h5info(fname);
 is_img_data = any(contains({file_info.Datasets.Name}, 'image'));
+is_nufft_reverse_data = any(contains({file_info.Datasets.Name}, 'nufft-backward'));
+is_nufft_forward_data = any(contains({file_info.Datasets.Name}, 'nufft-forward'));
 if is_img_data % load only image data
     data = h5read(fname, '/image');
+    img = data.r + 1j*data.i;
+    
+    varargout{1} = img;
+    varargout{2} = info;
+elseif is_nufft_forward_data
+    data = h5read(fname, '/nufft-forward');
+    img = data.r + 1j*data.i;
+    
+    varargout{1} = img;
+    varargout{2} = info;
+elseif is_nufft_reverse_data
+    data = h5read(fname, '/nufft-backward');
     img = data.r + 1j*data.i;
     
     varargout{1} = img;


### PR DESCRIPTION
Updated riesling_read.m to allow reading nufft reverse and forward .h5 dataset files. Perhaps there is a more elegant way to make this function robust to tensor names, i.e. use try statements to read data as complex / regular and output a struct object with fields corresponding to tensornames of the .h5 dataset, which would avoid having to code all the tensor names used in riesling, and allow for custom output names to work with these interfaces.

Updated riesling_write.m to allow writing cartesian datasets for use in the nufft command, to create tensors with the right dimensionality and naming convention used (by default) in the nufft command.

Added a riesling.m matlab interface (WIP), to abstract out the reading/writing of h5 datasets used in the riesling command, allowing "simple" calls to riesling with matlab variables.
