### PR TITLE
Bump cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(riesling LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 include(BuildType)


### PR DESCRIPTION
This PR bumps the required cmake_minimum_version, as "add_link_options" was introduced in CMake 3.13
See https://cmake.org/cmake/help/latest/command/add_link_options.html

Related to the discussion in #41 