### PR TITLE
Changed default dimensionality to 5

### DIFF
--- a/matlab/riesling_write.m
+++ b/matlab/riesling_write.m
@@ -19,11 +19,11 @@ if nargin > 4
     elseif strcmp(tensorName,'nufft-forward')
         Ndims = 3;
     else
-        Ndims = 4;
+        Ndims = 5;
     end
 else
     tensorName = 'noncartesian';
-    Ndims = 4;
+    Ndims = 5;
 end
 
 if isfile(fname)


### PR DESCRIPTION
If I'm not mistaken the dimensionality of k-space data is 5, i.e. ```nchannels, nsamples, ntraces, nslab, nvol```, however, the MATLAB script would set it to 4 by default, which, when then adding data that has ```nslab=1``` and ```nvol=1``` would result in only 4 dimensional data in the h5 file, causing ```Tensor noncartesian: Requested rank 5, on-disk rank 4``` when further processing the data with riesling.