### PR TITLE
Changed so that info, dsets and keys flags can be combined

### DIFF
--- a/src/cmd/h5.cpp
+++ b/src/cmd/h5.cpp
@@ -26,7 +26,8 @@ int main_h5(args::Subparser &parser)
       i.tr,
       i.origin.transpose(),
       i.direction);
-  } else if (dsets) {
+  } 
+  if (dsets) {
     auto const datasets = reader.list();
     if (datasets.empty()) { Log::Fail("No datasets found in {}", iname.Get()); }
     for (auto const &ds : datasets) {
@@ -41,7 +42,8 @@ int main_h5(args::Subparser &parser)
       default: fmt::print("rank is higher than 6\n");
       }
     }
-  } else if (keys) {
+  } 
+  if (keys) {
     auto const &meta = reader.readMeta();
     for (auto const &k : keys.Get()) {
       try {

--- a/src/cmd/h5.cpp
+++ b/src/cmd/h5.cpp
@@ -7,42 +7,10 @@ using namespace rl;
 int main_h5(args::Subparser &parser)
 {
   args::Positional<std::string>    iname(parser, "FILE", "Input HD5 file to dump info from");
-  args::Flag                       info(parser, "INFO", "Print header information", {"info", 'i'});
-  args::Flag                       dsets(parser, "DSETS", "List datasets and dimensions", {"dsets", 'd'});
   args::ValueFlagList<std::string> keys(parser, "KEYS", "Meta-data keys to be printed", {"meta", 'm'});
   ParseCommand(parser, iname);
   HD5::Reader reader(iname.Get());
 
-  if (info) {
-    auto const i = reader.readInfo();
-    fmt::print(
-      "Matrix:     {}\n"
-      "Voxel-size: {}\n"
-      "TR:         {}\n"
-      "Origin: {}\n"
-      "Direction:\n{}\n",
-      i.matrix,
-      i.voxel_size.transpose(),
-      i.tr,
-      i.origin.transpose(),
-      i.direction);
-  } 
-  if (dsets) {
-    auto const datasets = reader.list();
-    if (datasets.empty()) { Log::Fail("No datasets found in {}", iname.Get()); }
-    for (auto const &ds : datasets) {
-      fmt::print("{} ", ds);
-      switch (reader.rank(ds)) {
-      case 1: fmt::print("{}\n", reader.dimensions<1>(ds)); break;
-      case 2: fmt::print("{}\n", reader.dimensions<2>(ds)); break;
-      case 3: fmt::print("{}\n", reader.dimensions<3>(ds)); break;
-      case 4: fmt::print("{}\n", reader.dimensions<4>(ds)); break;
-      case 5: fmt::print("{}\n", reader.dimensions<5>(ds)); break;
-      case 6: fmt::print("{}\n", reader.dimensions<6>(ds)); break;
-      default: fmt::print("rank is higher than 6\n");
-      }
-    }
-  } 
   if (keys) {
     auto const &meta = reader.readMeta();
     for (auto const &k : keys.Get()) {
@@ -50,6 +18,42 @@ int main_h5(args::Subparser &parser)
         fmt::print("{}\n", meta.at(k));
       } catch (std::out_of_range const &) {
         Log::Fail("Could not find key {}", k);
+      }
+    }
+  } else {
+    // try to load info header
+    try {
+      auto const i = reader.readInfo();
+      fmt::print(
+        "Matrix:     {}\n"
+        "Voxel-size: {}\n"
+        "TR:         {}\n"
+        "Origin:     {}\n"
+        "Direction:\n{}\n",
+        i.matrix,
+        i.voxel_size.transpose(),
+        i.tr,
+        i.origin.transpose(),
+        i.direction);
+    } catch ( ... ) {
+      
+    }
+
+    // read dataset info
+    auto const datasets = reader.list();
+    if (datasets.empty()) { Log::Fail("No datasets found in {}", iname.Get()); }
+    for (auto const &ds : datasets) {
+      if (ds != "info") {
+        fmt::print("{} ", ds);
+        switch (reader.rank(ds)) {
+        case 1: fmt::print("{}\n", reader.dimensions<1>(ds)); break;
+        case 2: fmt::print("{}\n", reader.dimensions<2>(ds)); break;
+        case 3: fmt::print("{}\n", reader.dimensions<3>(ds)); break;
+        case 4: fmt::print("{}\n", reader.dimensions<4>(ds)); break;
+        case 5: fmt::print("{}\n", reader.dimensions<5>(ds)); break;
+        case 6: fmt::print("{}\n", reader.dimensions<6>(ds)); break;
+        default: fmt::print("rank is higher than 6\n");
+        }
       }
     }
   }


### PR DESCRIPTION
Super small change that makes it possible to combine the "-d" and "-i" flags for probing an h5 file, 
e.g.  ```riesling h5 -d -i data_riesling_aw2.h5```

will now print
```
Matrix:     [192, 160, 38]
Voxel-size:  2.08333  1.73611 0.833333
TR:         1.3
Origin: 0 0 0
Direction:
1 0 0
0 1 0
0 0 1
info [1]
noncartesian [16, 125, 8364, 1, 1]
trajectory [3, 125, 8364]
```

this just makes it easier to check out all infos of a file at once :-)