### PR TITLE
Improvements and fixes to python wrapper

### DIFF
--- a/python/riesling/data.py
+++ b/python/riesling/data.py
@@ -45,13 +45,14 @@ def write(filename, data, data_type='noncartesian'):
 
     with h5py.File(filename, 'w') as out_f:
         # write info header
-        out_f.create_dataset('info', data=_create_info(
-            data.attrs['matrix'],
-            data.attrs['voxel_size'],
-            data.attrs['tr'],
-            data.attrs['origin'],
-            data.attrs['direction'])
-        )
+        if {'matrix','voxel_size','tr','origin','direction'} <= data.attrs.keys():
+            out_f.create_dataset('info', data=_create_info(
+                data.attrs['matrix'],
+                data.attrs['voxel_size'],
+                data.attrs['tr'],
+                data.attrs['origin'],
+                data.attrs['direction'])
+            )
 
         # write additional information
         if 'trajectory' in data.attrs:

--- a/python/riesling/data.py
+++ b/python/riesling/data.py
@@ -54,8 +54,11 @@ def write(filename, data, data_type='noncartesian'):
         )
 
         # write additional information
-        if data_type == 'noncartesian':
+        if 'trajectory' in data.attrs:
             out_f.create_dataset('trajectory', data=data.attrs['trajectory'], chunks=np.shape(data.attrs['trajectory']), compression="gzip")
+
+        # define data dimensions
+        if data_type == 'noncartesian':
             data_dims = ['channel', 'sample', 'trace', 'slab', 'volume']
         elif data_type == 'cartesian' or data_type == 'channels':
             data_dims = ['channel', 'image', 'x', 'y', 'z', 'volume']

--- a/python/riesling/data.py
+++ b/python/riesling/data.py
@@ -58,7 +58,7 @@ def write(filename, data, data_type='noncartesian'):
             out_f.create_dataset('trajectory', data=data.attrs['trajectory'], chunks=np.shape(data.attrs['trajectory']), compression="gzip")
             data_dims = ['channel', 'sample', 'trace', 'slab', 'volume']
         elif data_type == 'cartesian' or data_type == 'channels':
-            data_dims = ['channel', 'image', 'x', 'y', 'z']
+            data_dims = ['channel', 'image', 'x', 'y', 'z', 'volume']
         elif data_type == 'sense':
             data_dims = ['channel', 'x', 'y', 'z']
         elif data_type == 'image':
@@ -98,7 +98,7 @@ def read(filename):
             if key == 'noncartesian':
                 dims = ['channel', 'sample', 'trace', 'slab', 'volume']
             elif key == 'cartesian' or key == 'channels':
-                dims = ['channel', 'image', 'x', 'y', 'z']
+                dims = ['channel', 'image', 'x', 'y', 'z', 'volume']
             elif key == 'sense':
                 dims = ['channel', 'x', 'y', 'z']
             elif key == 'image':
@@ -113,6 +113,7 @@ def read(filename):
         # build xarray output
         if (data.ndim) != len(dims):
             print(f'Number of dimensions in data does not match expected number of dimensions')
+            print(f'Data has shape {data.shape} and detected dimensions are {dims}')
             return None
         data = xr.DataArray(data, dims = dims)
         data.attrs.update(meta)


### PR DESCRIPTION
The following improvements and fixes have been made
* ```riesling.data.write()``` will only try to write the info header if all required attributes are present
* the ```trajectory``` attribute is now always written if it's present (before it was only written for 'noncartesian' data)
* Fixed 'cartesian' and 'channels' to 6D data