### PR TITLE
Python fix

### DIFF
--- a/python/riesling/io.py
+++ b/python/riesling/io.py
@@ -18,6 +18,9 @@ def write(filename, data=None, trajectory=None, matrix=None, info=None, meta=Non
             assert trajectory.ndim == 3, 'Trajectory must be 3 dimensional (co-ords, samples, traces)'
             assert trajectory.shape[2] <= 3, 'Trajectory cannot have more than 3 co-ordinates'
             traj = out_f.create_dataset('trajectory', dtype='f4', data=trajectory, compression=compression)
+            traj.dims[2].label = "k"
+            traj.dims[1].label = "sample"
+            traj.dims[0].label = "trace"
             if matrix is not None:
                 traj.create_attribute('matrix', dtype='i8', data=matrix)
 


### PR DESCRIPTION
A couple of improvements to the python load:

* Removed matrix_size from INFO_FIELDS as it's not longer a property of the info struct
* Added writing of dimension names to h5 dimension label for data and trajectory
* Fixed conversion of info struct to h5py compatible data structure
* Fixed assertions
* Fixed bug in read_meta()

with these changes a simple read/write test appears to produce consistent results, e.g.
```python
data = riesling.io.read_data('phantom.h5')
info = riesling.io.read_info('phantom.h5')
trajectory = riesling.io.read_trajectory('phantom.h5')
meta = riesling.io.read_meta('phantom.h5')
riesling.io.write('phantom_rewrite.h5', data, trajectory=trajectory, info=info, meta=meta)
```
does not crash anymore and will result in identical files:
```bash
$ riesling h5 phantom.h5
Voxel-size: [2, 2, 2]
TR:         1
Origin:     [-128, -128, -128]
Direction:
1 0 0
0 1 0
0 0 1
Name: data         Shape: [1, 128, 128, 128, 1]    Names: ["v", "x", "y", "z", "t"]
Name: trajectory   Shape: [3, 128, 16384]          Names: ["k", "sample", "trace"]


$ riesling h5 phantom_rewrite.h5
Voxel-size: [2, 2, 2]
TR:         1
Origin:     [-128, -128, -128]
Direction:
1 0 0
0 1 0
0 0 1
Name: data         Shape: [1, 128, 128, 128, 1]    Names: ["v", "x", "y", "z", "t"]
Name: trajectory   Shape: [3, 128, 16384]          Names: ["k", "sample", "trace"]
```
