### PR TITLE
Changed to use Auto-chunking

### DIFF
--- a/python/riesling/io.py
+++ b/python/riesling/io.py
@@ -16,7 +16,7 @@ def __info():
 def write(filename, data=None, trajectory=None, matrix=None, info=None, meta=None, compression='gzip'):
     with h5py.File(filename, 'w') as out_f:
         if data is not None: # create dataset and assign dimension labels
-            out_f.create_dataset('data', dtype='c8', data=data.data, chunks=np.shape(data.data), compression=compression)
+            out_f.create_dataset('data', dtype='c8', data=data.data, chunks=True, compression=compression)
             if hasattr(data, 'dims'):
                 for idd, dim in enumerate(data.dims):
                     out_f['data'].dims[idd].label = dim


### PR DESCRIPTION
Small change in python code to use Auto-chunking of h5py module.
There appears to be a limit that chunks in h5py have to be smaller than 4GB, so for large datasets setting the entire data object as chunk size will cause the error 
```ValueError: Unable to create dataset (chunk size must be < 4GB)```
Setting ```chunks=True``` will let h5py determine the chunk size automatically